### PR TITLE
Add an option to compile circuits in Docker for quick and easy installation 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "ffjavascript": "^0.2.38",
         "fnv-plus": "^1.3.1",
         "r1csfile": "0.0.16",
-        "tmp-promise": "^3.0.2",
+        "tmp-promise": "^3.0.3",
         "util": "^0.12.4"
       }
     },
@@ -711,9 +711,9 @@
       }
     },
     "node_modules/tmp-promise": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.2.tgz",
-      "integrity": "sha512-OyCLAKU1HzBjL6Ev3gxUeraJNlbNingmi8IrHHEsYH8LTmEuhvYfqvhn2F/je+mjf4N58UmZ96OMEy1JanSCpA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
       "dependencies": {
         "tmp": "^0.2.0"
       }
@@ -1302,9 +1302,9 @@
       }
     },
     "tmp-promise": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.2.tgz",
-      "integrity": "sha512-OyCLAKU1HzBjL6Ev3gxUeraJNlbNingmi8IrHHEsYH8LTmEuhvYfqvhn2F/je+mjf4N58UmZ96OMEy1JanSCpA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
       "requires": {
         "tmp": "^0.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ffjavascript": "^0.2.38",
     "fnv-plus": "^1.3.1",
     "r1csfile": "0.0.16",
-    "tmp-promise": "^3.0.2",
+    "tmp-promise": "^3.0.3",
     "util": "^0.12.4"
   }
 }

--- a/scripts/circom-docker.sh
+++ b/scripts/circom-docker.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+[[ $1 =~ (-h|--help) ]] && {
+  echo "usage: ${0##*/} <circom params>"
+  echo "e.g.:  ${0##*/} circuits/hello.circom --r1cs --wasm --sym --c --output compiled/"
+  exit 1
+}
+
+path_this=$( cd $(dirname "$0"); pwd -L )
+if [ -L "$0" ]; then
+  path_this=$(dirname $(readlink ${path_this}/$(basename "$0"))) # path relatively to the symlink file
+  [[ "$path_this" != /* ]] && path_this=$(cd $(dirname "$0")/${path_this}; pwd -L)
+fi
+
+test -t 1 && USE_TTY="-t" | USE_TTY=""
+
+docker run -i ${USE_TTY} --rm \
+  -v "${path_this}/..":/data \
+  -v /etc/passwd:/etc/passwd:ro \
+  -v /etc/group:/etc/group:ro \
+  --user $(id -u) \
+  aspiers/circom circom $@

--- a/test/helpers/circomDocker.js
+++ b/test/helpers/circomDocker.js
@@ -1,0 +1,33 @@
+const { mkdtemp, rmdirSync } = require("fs");
+const { tmpdir, userInfo } = require("os");
+const { join, sep } = require("path");
+
+module.exports = {
+    getOptions,
+};
+
+async function getOptions(projectRoot = "") {
+    const basedir = projectRoot || join(__dirname, "../../");
+    const options = {
+        basedir,
+    };
+    if (!!process.env.CIRCOM_DOCKER) {
+        const tmpDir = await new Promise((res, rej) =>
+            mkdtemp(`${tmpdir()}${sep}`, (err, folder) =>
+                err ? rej(err) : res(folder)
+            )
+        );
+        process.on("exit", () => rmdirSync(tmpDir, { recursive: true }));
+        options.tmpdir = tmpDir;
+
+        options.compiler = `docker run -i --rm -v ${basedir}:/data -v ${tmpDir}:${tmpDir} `;
+        const { uid } = userInfo();
+        if (!!uid) {
+            options.compiler += `-v /etc/passwd:/etc/passwd:ro `;
+            options.compiler += `-v /etc/group:/etc/group:ro `;
+            options.compiler += `--user ${uid} `;
+        }
+        options.compiler += "aspiers/circom circom";
+    }
+    return Promise.resolve(options);
+}

--- a/test/multiplier2.js
+++ b/test/multiplier2.js
@@ -15,7 +15,9 @@ describe("Simple test", function () {
 
     it("Checking the compilation of a simple circuit generating wasm", async () => {
 
-        const circuit = await wasm_tester(path.join(__dirname, "Multiplier2.circom"));
+        const input = path.join(__dirname, "Multiplier2.circom");
+        const opts = await getOptions(__dirname);
+        const circuit = await wasm_tester(input, opts);
         const w = await circuit.calculateWitness({a: 2, b: 4});
         await circuit.checkConstraints(w);
     });


### PR DESCRIPTION
Circuits __compilation inside a Docker__ container running `circom`.

_To simplify/avoid installation of dependencies (`circom`):_

- [ ] WASM tester updated to support compilation of circuits in a container during test run
- [ ] Bash script added for circuits compilation inside a container (w/o the tester)
- [ ] Test helper added for configuration of the WASM tester to work with `circom` in a conainer
- [ ] Test examples extended to demonstrate compilation inside a container

