### PR TITLE
Propagate compile errors

### DIFF
--- a/wasm/tester.js
+++ b/wasm/tester.js
@@ -87,6 +87,9 @@ async function compile (fileName, options) {
 	if (options.verbose) {
             console.log(b.stdout);
 	}
+	if (b.stderr != '') {
+		throw(b.stderr);
+        }
     } catch (e) {
 	assert(false,
 	       "circom compiler error \n" + e);


### PR DESCRIPTION
I had a compilation error in my circuit, which failed quietly and didn't generate the output wasm in the tmp directory.

So I ended up with an error like `Error: ENOENT: no such file or directory, open '/var/folders/d1/p4jvjs_s1jb30fn8hky7hr5c0000gn/T/circom_-34177-Og3xuSwqOMjn/membership_test_js/membership_test.wasm'`, where that directory doesn't even exist because it was cleaned up.

(Not 100% sure this will replicate or whether it's the most robust solution).