### PR TITLE
Support JSON debugging output

### DIFF
--- a/test/multiplier2.js
+++ b/test/multiplier2.js
@@ -18,7 +18,11 @@ describe("Simple test", function () {
         const circuit = await wasm_tester(
 	    path.join(__dirname, "Multiplier2.circom")
 	);
-        const w = await circuit.calculateWitness({a: 2, b: 4});
+        const a = 2;
+        const b = 4;
+        const w = await circuit.calculateWitness({a, b});
+        const signals = await circuit.getJSONOutput('main', w);
+        assert(signals.main.c == BigInt(a * b));
         await circuit.checkConstraints(w);
     });
     
@@ -28,7 +32,11 @@ describe("Simple test", function () {
 	    { output : path.join(__dirname),
 	    }
 	);
-        const w = await circuit.calculateWitness({a: 2, b: 4});
+        const a = 2;
+        const b = 4;
+        const w = await circuit.calculateWitness({a, b});
+        const signals = await circuit.getJSONOutput('main', w);
+        assert(signals.main.c == BigInt(a * b));
         await circuit.checkConstraints(w);
     });
     
@@ -39,7 +47,12 @@ describe("Simple test", function () {
 	      recompile : false,
 	    }
 	);
-        const w = await circuit.calculateWitness({a: 6, b: 3});
+        const a = 6;
+        const b = 3;
+        const w = await circuit.calculateWitness({a, b});
+        const signals = await circuit.getJSONOutput('main', w);
+        assert(signals.main.c == BigInt(a * b));
+
         await circuit.checkConstraints(w);
 	
     });


### PR DESCRIPTION
This PR added API `getJSONOutput`, which can search and parse signals based on object keyword, such as this [test](https://github.com/iden3/circom_tester/compare/main...katat:circom_tester:feat/signal-json?expand=1#diff-9dc18beba0b7cc194929d76d55e5a6dff9932d1604d8c2d17263e7deffa07aa2R24). Any symbol string matching the [regex text](https://github.com/iden3/circom_tester/compare/main...katat:circom_tester:feat/signal-json?expand=1#diff-0aa72b49646487e9666ad5f35612e20f9ad4a87983fc586778152aef6325174fR241) will be parsed and organized as json output for testing assertions.

This would be particularly useful when the number of different signals is large as it helps navigate the debugging targets without costing too much overhead unnecessarily parsing all the signals for every test.