### PR TITLE
print stderr from compilation

### DIFF
--- a/c/tester.js
+++ b/c/tester.js
@@ -82,6 +82,11 @@ async function compile (baseName, fileName, options) {
 	if (options.verbose) {
             console.log(b.stdout);
 	}
+
+    if (b.stderr) {
+        console.error(b.stderr);
+    }
+    
     } catch (e) {
 	assert(false,
 	       "circom compiler error \n" + e);

--- a/wasm/tester.js
+++ b/wasm/tester.js
@@ -87,6 +87,11 @@ async function compile (fileName, options) {
 	if (options.verbose) {
             console.log(b.stdout);
 	}
+
+    if (b.stderr) {
+        console.error(b.stderr);
+    }
+    
     } catch (e) {
 	assert(false,
 	       "circom compiler error \n" + e);


### PR DESCRIPTION
The tests fail if there is a compilation error (e.g. due to syntax error). But there is no way of knowing the error or its location in the circuit as there is no such output on console at all. Added a couple of `console.error`s to fix that.