### PR TITLE
Don't fail at make warnings & deps update

### DIFF
--- a/c/tester.js
+++ b/c/tester.js
@@ -59,7 +59,7 @@ async function  c_tester(circomInput, _options) {
 }
 
 async function compile (baseName, fileName, options) {
-    var flags = "--c ";
+    let flags = "--c ";
     if (options.include) {
         if (Array.isArray(options.include)) {
             for (let i=0; i<options.include.length;i++) {
@@ -78,19 +78,23 @@ async function compile (baseName, fileName, options) {
     if (options.verbose) flags += "--verbose ";
 
     try {
-	b = await exec("circom " + flags + fileName);
+	let b = await exec("circom " + flags + fileName);
 	if (options.verbose) {
             console.log(b.stdout);
 	}
+        if (b.stderr) {
+            console.error(b.stderr);
+        }
     } catch (e) {
 	assert(false,
 	       "circom compiler error \n" + e);
     }
 
     const c_folder = path.join(options.output, baseName+"_cpp/")
-    b = await exec("make -C "+c_folder);
-    assert(b.stderr == "",
-	   "error building the executable C program\n" + b.stderr);
+    let b = await exec("make -C "+c_folder);
+    if (b.stderr) {
+        console.error(b.stderr);
+    }
 }
 
 class CTester {
@@ -117,6 +121,9 @@ class CTester {
         let proc = await exec(runc + " " + inputFile + " " + wtnsFile);
         if (proc.stdout !== "") {
             console.log(proc.stdout);
+        }
+        if (proc.stderr !== "") {
+            console.error(proc.stderr);
         }
 	return await readBinWitnessFile(wtnsFile);
     }

--- a/c/tester.js
+++ b/c/tester.js
@@ -75,9 +75,11 @@ async function compile(baseName, fileName, options) {
     if (options.r1cs) flags += "--r1cs ";
     if (options.json) flags += "--json ";
     if (options.output) flags += "--output " + options.output + " ";
+    if (options.prime) flags += "--prime " + options.prime + " ";
     if (options.O === 0) flags += "--O0 ";
     if (options.O === 1) flags += "--O1 ";
     if (options.verbose) flags += "--verbose ";
+    if (options.inspect) flags += "--inspect ";
 
     try {
         let b = await exec("circom " + flags + fileName);

--- a/c/tester.js
+++ b/c/tester.js
@@ -2,11 +2,11 @@ const chai = require("chai");
 const assert = chai.assert;
 
 const fs = require("fs");
-var tmp = require("tmp-promise");
+const tmp = require("tmp-promise");
 const path = require("path");
 
 const util = require("util");
-const { F1Field } = require("ffjavascript");
+const {F1Field} = require("ffjavascript");
 const exec = util.promisify(require("child_process").exec);
 
 const readR1cs = require("r1csfile").readR1cs;
@@ -16,11 +16,13 @@ const readWtns = require("snarkjs").wtns.exportJson;
 
 module.exports = c_tester;
 
-BigInt.prototype.toJSON = function() { return this.toString() }
+BigInt.prototype.toJSON = function () {
+    return this.toString()
+}
 
-async function  c_tester(circomInput, _options) {
+async function c_tester(circomInput, _options) {
 
-    assert(await compiler_above_version("2.0.0"),"Wrong compiler version. Must be at least 2.0.0");
+    assert(await compiler_above_version("2.0.0"), "Wrong compiler version. Must be at least 2.0.0");
 
     const baseName = path.basename(circomInput, ".circom");
     const options = Object.assign({}, _options);
@@ -30,43 +32,43 @@ async function  c_tester(circomInput, _options) {
     options.sym = true;
     options.json = options.json || false; // costraints in json format
     options.r1cs = true;
-    options.compile = (typeof options.recompile  === 'undefined')? true : options.recompile; // by default compile
+    options.compile = (typeof options.recompile === 'undefined') ? true : options.recompile; // by default compile
 
-    if (typeof options.output  === 'undefined') {
-	tmp.setGracefulCleanup();
-        const dir = await tmp.dir({prefix: "circom_", unsafeCleanup: true });
-	//console.log(dir.path);
-	options.output = dir.path;
+    if (typeof options.output === 'undefined') {
+        tmp.setGracefulCleanup();
+        const dir = await tmp.dir({prefix: "circom_", unsafeCleanup: true});
+        //console.log(dir.path);
+        options.output = dir.path;
     } else {
-	try {
+        try {
             await fs.promises.access(options.output);
-	} catch (err) {
-	    assert(options.compile,"Cannot set recompile to false if the output path does not exist");
-	    await fs.promises.mkdir(options.output, { recursive: true });
-	}
+        } catch (err) {
+            assert(options.compile, "Cannot set recompile to false if the output path does not exist");
+            await fs.promises.mkdir(options.output, {recursive: true});
+        }
     }
     if (options.compile) {
-	await compile(baseName, circomInput, options);
+        await compile(baseName, circomInput, options);
     } else {
-	const jsPath = path.join(options.output, baseName+"_js");
-	try {
-	    await fs.promises.access(jsPath);
-	} catch (err) {
-	    assert(false,"Cannot set recompile to false if the "+jsPath+" folder does not exist");
-	}
+        const jsPath = path.join(options.output, baseName + "_js");
+        try {
+            await fs.promises.access(jsPath);
+        } catch (err) {
+            assert(false, "Cannot set recompile to false if the " + jsPath + " folder does not exist");
+        }
     }
     return new CTester(options.output, baseName, run);
 }
 
-async function compile (baseName, fileName, options) {
+async function compile(baseName, fileName, options) {
     let flags = "--c ";
     if (options.include) {
         if (Array.isArray(options.include)) {
-            for (let i=0; i<options.include.length;i++) {
-                flags += "-l "+options.include[i] + " ";
+            for (let i = 0; i < options.include.length; i++) {
+                flags += "-l " + options.include[i] + " ";
             }
         } else {
-            flags += "-l "+options.include+ " ";
+            flags += "-l " + options.include + " ";
         }
     }
     if (options.sym) flags += "--sym ";
@@ -78,20 +80,20 @@ async function compile (baseName, fileName, options) {
     if (options.verbose) flags += "--verbose ";
 
     try {
-	      let b = await exec("circom " + flags + fileName);
-	if (options.verbose) {
+        let b = await exec("circom " + flags + fileName);
+        if (options.verbose) {
             console.log(b.stdout);
-   	    }
+        }
         if (b.stderr) {
             console.error(b.stderr);
         }
     } catch (e) {
-	      assert(false,
-	             "circom compiler error \n" + e);
+        assert(false,
+            "circom compiler error \n" + e);
     }
 
-    const c_folder = path.join(options.output, baseName+"_cpp/")
-    let b = await exec("make -C "+c_folder);
+    const c_folder = path.join(options.output, baseName + "_cpp/")
+    let b = await exec("make -C " + c_folder);
     if (b.stderr) {
         console.error(b.stderr);
     }
@@ -100,7 +102,7 @@ async function compile (baseName, fileName, options) {
 class CTester {
 
     constructor(dir, baseName, witnessCalculator) {
-        this.dir=dir;
+        this.dir = dir;
         this.baseName = baseName;
         this.witnessCalculator = witnessCalculator;
     }
@@ -110,14 +112,14 @@ class CTester {
     }
 
     async calculateWitness(input) {
-	const inputjson = JSON.stringify(input);
-	const inputFile = path.join(this.dir, this.baseName+"_cpp/" + this.baseName + ".json");
-	const wtnsFile = path.join(this.dir, this.baseName+"_cpp/" + this.baseName + ".wtns");
-	const runc = path.join(this.dir, this.baseName+"_cpp/" + this.baseName);
-        fs.writeFile(inputFile, inputjson, function(err) {
-	    if (err) throw err;
-	});
-	await exec("cd " + path.join(this.dir, this.baseName+"_cpp/"));
+        const inputjson = JSON.stringify(input);
+        const inputFile = path.join(this.dir, this.baseName + "_cpp/" + this.baseName + ".json");
+        const wtnsFile = path.join(this.dir, this.baseName + "_cpp/" + this.baseName + ".wtns");
+        const runc = path.join(this.dir, this.baseName + "_cpp/" + this.baseName);
+        fs.writeFile(inputFile, inputjson, function (err) {
+            if (err) throw err;
+        });
+        await exec("cd " + path.join(this.dir, this.baseName + "_cpp/"));
         let proc = await exec(runc + " " + inputFile + " " + wtnsFile);
         if (proc.stdout !== "") {
             console.log(proc.stdout);
@@ -125,7 +127,7 @@ class CTester {
         if (proc.stderr !== "") {
             console.error(proc.stderr);
         }
-	return await readBinWitnessFile(wtnsFile);
+        return await readBinWitnessFile(wtnsFile);
     }
 
     async loadSymbols() {
@@ -136,9 +138,9 @@ class CTester {
             "utf8"
         );
         const lines = symsStr.split("\n");
-        for (let i=0; i<lines.length; i++) {
+        for (let i = 0; i < lines.length; i++) {
             const arr = lines[i].split(",");
-            if (arr.length!=4) continue;
+            if (arr.length != 4) continue;
             this.symbols[arr[3]] = {
                 labelIdx: Number(arr[0]),
                 varIdx: Number(arr[1]),
@@ -150,7 +152,7 @@ class CTester {
     async loadConstraints() {
         const self = this;
         if (this.constraints) return;
-        const r1cs = await readR1cs(path.join(this.dir, this.baseName + ".r1cs"),{
+        const r1cs = await readR1cs(path.join(this.dir, this.baseName + ".r1cs"), {
             loadConstraints: true,
             loadMap: false,
             getFieldFromPrime: (p, singlethread) => new F1Field(p)
@@ -169,16 +171,16 @@ class CTester {
         function checkObject(prefix, eOut) {
 
             if (Array.isArray(eOut)) {
-                for (let i=0; i<eOut.length; i++) {
-                    checkObject(prefix + "["+i+"]", eOut[i]);
+                for (let i = 0; i < eOut.length; i++) {
+                    checkObject(prefix + "[" + i + "]", eOut[i]);
                 }
-            } else if ((typeof eOut == "object")&&(eOut.constructor.name == "Object")) {
+            } else if ((typeof eOut == "object") && (eOut.constructor.name == "Object")) {
                 for (let k in eOut) {
-                    checkObject(prefix + "."+k, eOut[k]);
+                    checkObject(prefix + "." + k, eOut[k]);
                 }
             } else {
                 if (typeof self.symbols[prefix] == "undefined") {
-                    assert(false, "Output variable not defined: "+ prefix);
+                    assert(false, "Output variable not defined: " + prefix);
                 }
                 const ba = actualOut[self.symbols[prefix].varIdx].toString();
                 const be = eOut.toString();
@@ -206,7 +208,7 @@ class CTester {
     async checkConstraints(witness) {
         const self = this;
         if (!self.constraints) await self.loadConstraints();
-        for (let i=0; i<self.constraints.length; i++) {
+        for (let i = 0; i < self.constraints.length; i++) {
             checkConstraint(self.constraints[i]);
         }
 
@@ -216,7 +218,7 @@ class CTester {
             const a = evalLC(constraint[0]);
             const b = evalLC(constraint[1]);
             const c = evalLC(constraint[2]);
-            assert (F.isZero(F.sub(F.mul(a,b), c)), "Constraint doesn't match");
+            assert(F.isZero(F.sub(F.mul(a, b), c)), "Constraint doesn't match");
         }
 
         function evalLC(lc) {
@@ -225,7 +227,7 @@ class CTester {
             for (let w in lc) {
                 v = F.add(
                     v,
-                    F.mul( lc[w], F.e(witness[w]) )
+                    F.mul(lc[w], F.e(witness[w]))
                 );
             }
             return v;
@@ -234,26 +236,26 @@ class CTester {
 
 }
 
-function version_to_list ( v ) {
-    return v.split(".").map(function(x) {
-	return parseInt(x, 10);
+function version_to_list(v) {
+    return v.split(".").map(function (x) {
+        return parseInt(x, 10);
     });
 }
 
-function check_versions ( v1, v2 ) {
+function check_versions(v1, v2) {
     //check if v1 is newer than or equal to v2
     for (let i = 0; i < v2.length; i++) {
-	if (v1[i] > v2[i]) return true;
-	if (v1[i] < v2[i]) return false;
+        if (v1[i] > v2[i]) return true;
+        if (v1[i] < v2[i]) return false;
     }
     return true;
 }
 
 async function compiler_above_version(v) {
     let output = (await exec('circom --version')).stdout;
-    let compiler_version = version_to_list(output.slice(output.search(/\d/),-1));
+    let compiler_version = version_to_list(output.slice(output.search(/\d/), -1));
     let vlist = version_to_list(v);
-    return check_versions ( compiler_version, vlist );
+    return check_versions(compiler_version, vlist);
 }
 
 async function readBinWitnessFile(fileName) {
@@ -262,19 +264,19 @@ async function readBinWitnessFile(fileName) {
 }
 
 function fromArray8(arr) { //returns a BigInt
-    var res = BigInt(0);
+    let res = BigInt(0);
     const radix = BigInt(0x100);
-    for (let i = arr.length-1 ; i>=0; i--) {
-        res = res*radix + BigInt(arr[i]);
+    for (let i = arr.length - 1; i >= 0; i--) {
+        res = res * radix + BigInt(arr[i]);
     }
     return res;
 }
 
 function fromArray8ToUint(arr) { //returns a BigInt
-    var res = 0;
+    let res = 0;
     const radix = 8;
-    for (let i = arr.length-1 ; i>=0; i--) {
-        res = res*radix + arr[i];
+    for (let i = arr.length - 1; i >= 0; i--) {
+        res = res * radix + arr[i];
     }
     return res;
 }

--- a/c/tester.js
+++ b/c/tester.js
@@ -252,7 +252,7 @@ function check_versions ( v1, v2 ) {
 async function compiler_above_version(v) {
     let output = (await exec('circom --version')).stdout;
     let compiler_version = version_to_list(output.slice(output.search(/\d/),-1));
-    vlist = version_to_list(v);
+    let vlist = version_to_list(v);
     return check_versions ( compiler_version, vlist );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,18 +10,17 @@
       "license": "GPL-3.0",
       "dependencies": {
         "chai": "^4.3.6",
-        "child_process": "^1.0.2",
-        "ffjavascript": "^0.2.56",
+        "ffjavascript": "^0.2.60",
         "fnv-plus": "^1.3.1",
-        "r1csfile": "^0.0.41",
-        "snarkjs": "0.5.0",
+        "r1csfile": "^0.0.47",
+        "snarkjs": "^0.7.0",
         "tmp-promise": "^3.0.3",
-        "util": "^0.12.4"
+        "util": "^0.12.5"
       },
       "devDependencies": {
-        "@types/chai": "^4.3.1",
-        "@types/mocha": "^9.1.1",
-        "mocha": "^10.0.0"
+        "@types/chai": "^4.3.6",
+        "@types/mocha": "^10.0.1",
+        "mocha": "^10.1.0"
       }
     },
     "node_modules/@iden3/bigarray": {
@@ -39,21 +38,15 @@
       }
     },
     "node_modules/@types/chai": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.3.tgz",
-      "integrity": "sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-VOVRLM1mBxIRxydiViqPcKn6MIxZytrbMpd6RJLIWKxUNr3zux8no0Oc7kJx0WAPIitgZ0gkrDS+btlqQpubpw==",
       "dev": true
     },
     "node_modules/@types/mocha": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
-      "dev": true
-    },
-    "node_modules/@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
+      "integrity": "sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==",
       "dev": true
     },
     "node_modules/ansi-colors": {
@@ -274,11 +267,6 @@
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
       "integrity": "sha512-tzWzvgePgLORb9/3a0YenggReLKAIb2owL03H2Xdoe5pKcUyWRSEQ8xfCar8t2SIAuEDwtmx2da1YB52YuHQMQ=="
     },
-    "node_modules/child_process": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
-      "integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o="
-    },
     "node_modules/chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -307,14 +295,24 @@
       }
     },
     "node_modules/circom_runtime": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/circom_runtime/-/circom_runtime-0.1.21.tgz",
-      "integrity": "sha512-qTkud630B/GK8y76hnOaaS1aNuF6prfV0dTrkeRsiJKnlP1ryQbP2FWLgDOPqn6aKyaPlam+Z+DTbBhkEzh8dA==",
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/circom_runtime/-/circom_runtime-0.1.22.tgz",
+      "integrity": "sha512-V/XYZWBhbZY8SotkaGH4FbiDYAZ8a1Md++MBiKPDOuWS/NIJB+Q+XIiTC8zKMgoDaa9cd2OiTvsC9J6te7twNg==",
       "dependencies": {
-        "ffjavascript": "0.2.56"
+        "ffjavascript": "0.2.57"
       },
       "bin": {
         "calcwit": "calcwit.js"
+      }
+    },
+    "node_modules/circom_runtime/node_modules/ffjavascript": {
+      "version": "0.2.57",
+      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.57.tgz",
+      "integrity": "sha512-V+vxZ/zPNcthrWmqfe/1YGgqdkTamJeXiED0tsk7B84g40DKlrTdx47IqZuiygqAVG6zMw4qYuvXftIJWsmfKQ==",
+      "dependencies": {
+        "wasmbuilder": "0.0.16",
+        "wasmcurves": "0.2.0",
+        "web-worker": "^1.2.0"
       }
     },
     "node_modules/cliui": {
@@ -511,13 +509,21 @@
       "integrity": "sha512-r5ZDbgImvVWCP0lA/cGNgQcZqR+aYdFx3u+CtJqUE510pBUVGMn4ulL/iRTI4tACTYsNJ736uzFxEBXesPAktA=="
     },
     "node_modules/ffjavascript": {
-      "version": "0.2.56",
-      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.56.tgz",
-      "integrity": "sha512-em6G5Lrj7ucIqj4TYEgyoHs/j99Urwwqa4+YxEVY2hggnpRimVj+noX5pZQTxI1pvtiekZI4rG65JBf0xraXrg==",
+      "version": "0.2.60",
+      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.60.tgz",
+      "integrity": "sha512-T/9bnEL5xAZRDbQoEMf+pM9nrhK+C3JyZNmqiWub26EQorW7Jt+jR54gpqDhceA4Nj0YctPQwYnl8xa52/A26A==",
       "dependencies": {
         "wasmbuilder": "0.0.16",
-        "wasmcurves": "0.2.0",
+        "wasmcurves": "0.2.2",
         "web-worker": "^1.2.0"
+      }
+    },
+    "node_modules/ffjavascript/node_modules/wasmcurves": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.2.2.tgz",
+      "integrity": "sha512-JRY908NkmKjFl4ytnTu5ED6AwPD+8VJ9oc94kdq7h5bIwbj0L4TDJ69mG+2aLs2SoCmGfqIesMWTEJjtYsoQXQ==",
+      "dependencies": {
+        "wasmbuilder": "0.0.16"
       }
     },
     "node_modules/filelist": {
@@ -1126,9 +1132,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1137,12 +1143,11 @@
       }
     },
     "node_modules/mocha": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
-      "integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
       "dev": true,
       "dependencies": {
-        "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.3",
@@ -1354,14 +1359,14 @@
       }
     },
     "node_modules/r1csfile": {
-      "version": "0.0.41",
-      "resolved": "https://registry.npmjs.org/r1csfile/-/r1csfile-0.0.41.tgz",
-      "integrity": "sha512-Q1WDF3u1vYeAwjHo4YuddkA8Aq0TulbKjmGm99+Atn13Lf5fTsMZBnBV9T741w8iSyPFG6Uh6sapQby77sREqA==",
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/r1csfile/-/r1csfile-0.0.47.tgz",
+      "integrity": "sha512-oI4mAwuh1WwuFg95eJDNDDL8hCaZkwnPuNZrQdLBWvDoRU7EG+L/MOHL7SwPW2Y+ZuYcTLpj3rBkgllBQZN/JA==",
       "dependencies": {
         "@iden3/bigarray": "0.0.2",
         "@iden3/binfileutils": "0.0.11",
         "fastfile": "0.0.20",
-        "ffjavascript": "0.2.56"
+        "ffjavascript": "0.2.60"
       }
     },
     "node_modules/randombytes": {
@@ -1412,6 +1417,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1450,23 +1456,70 @@
       }
     },
     "node_modules/snarkjs": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/snarkjs/-/snarkjs-0.5.0.tgz",
-      "integrity": "sha512-KWz8mZ2Y+6wvn6GGkQo6/ZlKwETdAGohd40Lzpwp5TUZCn6N6O4Az1SuX1rw/qREGL6Im+ycb19suCFE8/xaKA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/snarkjs/-/snarkjs-0.7.0.tgz",
+      "integrity": "sha512-Vu5W+0Va6X1xvlCllpZ2r3/S7MafnL6IrAv09lk/F+VNDHuHEHx3xopR9Kr70p2KpbBBJ/HB9VCDZWism8WGlA==",
       "dependencies": {
         "@iden3/binfileutils": "0.0.11",
         "bfj": "^7.0.2",
         "blake2b-wasm": "^2.4.0",
-        "circom_runtime": "0.1.21",
+        "circom_runtime": "0.1.22",
         "ejs": "^3.1.6",
         "fastfile": "0.0.20",
-        "ffjavascript": "0.2.56",
+        "ffjavascript": "0.2.59",
         "js-sha3": "^0.8.0",
         "logplease": "^1.2.15",
-        "r1csfile": "0.0.41"
+        "r1csfile": "0.0.45"
       },
       "bin": {
         "snarkjs": "build/cli.cjs"
+      }
+    },
+    "node_modules/snarkjs/node_modules/ffjavascript": {
+      "version": "0.2.59",
+      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.59.tgz",
+      "integrity": "sha512-QssOEUv+wilz9Sg7Zaj6KWAm7QceOAEsFuEBTltUsDo1cjn11rA/LGYvzFBPbzNfxRlZxwgJ7uxpCQcdDlrNfw==",
+      "dependencies": {
+        "wasmbuilder": "0.0.16",
+        "wasmcurves": "0.2.1",
+        "web-worker": "^1.2.0"
+      }
+    },
+    "node_modules/snarkjs/node_modules/r1csfile": {
+      "version": "0.0.45",
+      "resolved": "https://registry.npmjs.org/r1csfile/-/r1csfile-0.0.45.tgz",
+      "integrity": "sha512-YKIp4D441aZ6OoI9y+bfAyb2j4Cl+OFq/iiX6pPWDrL4ZO968h0dq0w07i65edvrTt7/G43mTnl0qEuLXyp/Yw==",
+      "dependencies": {
+        "@iden3/bigarray": "0.0.2",
+        "@iden3/binfileutils": "0.0.11",
+        "fastfile": "0.0.20",
+        "ffjavascript": "0.2.57"
+      }
+    },
+    "node_modules/snarkjs/node_modules/r1csfile/node_modules/ffjavascript": {
+      "version": "0.2.57",
+      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.57.tgz",
+      "integrity": "sha512-V+vxZ/zPNcthrWmqfe/1YGgqdkTamJeXiED0tsk7B84g40DKlrTdx47IqZuiygqAVG6zMw4qYuvXftIJWsmfKQ==",
+      "dependencies": {
+        "wasmbuilder": "0.0.16",
+        "wasmcurves": "0.2.0",
+        "web-worker": "^1.2.0"
+      }
+    },
+    "node_modules/snarkjs/node_modules/r1csfile/node_modules/wasmcurves": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.2.0.tgz",
+      "integrity": "sha512-3e2rbxdujOwaod657gxgmdhZNn+i1qKdHO3Y/bK+8E7bV8ttV/fu5FO4/WLBACF375cK0QDLOP+65Na63qYuWA==",
+      "dependencies": {
+        "wasmbuilder": "0.0.16"
+      }
+    },
+    "node_modules/snarkjs/node_modules/wasmcurves": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.2.1.tgz",
+      "integrity": "sha512-9ciO7bUE5bgpbOcdK7IO3enrSVIKHwrQmPibok4GLJWaCA7Wyqc9PRYnu5HbiFv9NDFNqVKPtU5R6Is5KujBLg==",
+      "dependencies": {
+        "wasmbuilder": "0.0.16"
       }
     },
     "node_modules/string-width": {
@@ -1601,15 +1654,14 @@
       }
     },
     "node_modules/util": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
         "is-generator-function": "^1.0.7",
         "is-typed-array": "^1.1.3",
-        "safe-buffer": "^5.1.2",
         "which-typed-array": "^1.1.2"
       }
     },
@@ -1773,21 +1825,15 @@
       }
     },
     "@types/chai": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.3.tgz",
-      "integrity": "sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-VOVRLM1mBxIRxydiViqPcKn6MIxZytrbMpd6RJLIWKxUNr3zux8no0Oc7kJx0WAPIitgZ0gkrDS+btlqQpubpw==",
       "dev": true
     },
     "@types/mocha": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
-      "dev": true
-    },
-    "@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
+      "integrity": "sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==",
       "dev": true
     },
     "ansi-colors": {
@@ -1954,11 +2000,6 @@
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
       "integrity": "sha512-tzWzvgePgLORb9/3a0YenggReLKAIb2owL03H2Xdoe5pKcUyWRSEQ8xfCar8t2SIAuEDwtmx2da1YB52YuHQMQ=="
     },
-    "child_process": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
-      "integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o="
-    },
     "chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -1976,11 +2017,23 @@
       }
     },
     "circom_runtime": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/circom_runtime/-/circom_runtime-0.1.21.tgz",
-      "integrity": "sha512-qTkud630B/GK8y76hnOaaS1aNuF6prfV0dTrkeRsiJKnlP1ryQbP2FWLgDOPqn6aKyaPlam+Z+DTbBhkEzh8dA==",
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/circom_runtime/-/circom_runtime-0.1.22.tgz",
+      "integrity": "sha512-V/XYZWBhbZY8SotkaGH4FbiDYAZ8a1Md++MBiKPDOuWS/NIJB+Q+XIiTC8zKMgoDaa9cd2OiTvsC9J6te7twNg==",
       "requires": {
-        "ffjavascript": "0.2.56"
+        "ffjavascript": "0.2.57"
+      },
+      "dependencies": {
+        "ffjavascript": {
+          "version": "0.2.57",
+          "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.57.tgz",
+          "integrity": "sha512-V+vxZ/zPNcthrWmqfe/1YGgqdkTamJeXiED0tsk7B84g40DKlrTdx47IqZuiygqAVG6zMw4qYuvXftIJWsmfKQ==",
+          "requires": {
+            "wasmbuilder": "0.0.16",
+            "wasmcurves": "0.2.0",
+            "web-worker": "^1.2.0"
+          }
+        }
       }
     },
     "cliui": {
@@ -2126,13 +2179,23 @@
       "integrity": "sha512-r5ZDbgImvVWCP0lA/cGNgQcZqR+aYdFx3u+CtJqUE510pBUVGMn4ulL/iRTI4tACTYsNJ736uzFxEBXesPAktA=="
     },
     "ffjavascript": {
-      "version": "0.2.56",
-      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.56.tgz",
-      "integrity": "sha512-em6G5Lrj7ucIqj4TYEgyoHs/j99Urwwqa4+YxEVY2hggnpRimVj+noX5pZQTxI1pvtiekZI4rG65JBf0xraXrg==",
+      "version": "0.2.60",
+      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.60.tgz",
+      "integrity": "sha512-T/9bnEL5xAZRDbQoEMf+pM9nrhK+C3JyZNmqiWub26EQorW7Jt+jR54gpqDhceA4Nj0YctPQwYnl8xa52/A26A==",
       "requires": {
         "wasmbuilder": "0.0.16",
-        "wasmcurves": "0.2.0",
+        "wasmcurves": "0.2.2",
         "web-worker": "^1.2.0"
+      },
+      "dependencies": {
+        "wasmcurves": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.2.2.tgz",
+          "integrity": "sha512-JRY908NkmKjFl4ytnTu5ED6AwPD+8VJ9oc94kdq7h5bIwbj0L4TDJ69mG+2aLs2SoCmGfqIesMWTEJjtYsoQXQ==",
+          "requires": {
+            "wasmbuilder": "0.0.16"
+          }
+        }
       }
     },
     "filelist": {
@@ -2547,20 +2610,19 @@
       }
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
     "mocha": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
-      "integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
       "dev": true,
       "requires": {
-        "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.3",
@@ -2706,14 +2768,14 @@
       "dev": true
     },
     "r1csfile": {
-      "version": "0.0.41",
-      "resolved": "https://registry.npmjs.org/r1csfile/-/r1csfile-0.0.41.tgz",
-      "integrity": "sha512-Q1WDF3u1vYeAwjHo4YuddkA8Aq0TulbKjmGm99+Atn13Lf5fTsMZBnBV9T741w8iSyPFG6Uh6sapQby77sREqA==",
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/r1csfile/-/r1csfile-0.0.47.tgz",
+      "integrity": "sha512-oI4mAwuh1WwuFg95eJDNDDL8hCaZkwnPuNZrQdLBWvDoRU7EG+L/MOHL7SwPW2Y+ZuYcTLpj3rBkgllBQZN/JA==",
       "requires": {
         "@iden3/bigarray": "0.0.2",
         "@iden3/binfileutils": "0.0.11",
         "fastfile": "0.0.20",
-        "ffjavascript": "0.2.56"
+        "ffjavascript": "0.2.60"
       }
     },
     "randombytes": {
@@ -2751,7 +2813,8 @@
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
     },
     "serialize-javascript": {
       "version": "6.0.0",
@@ -2773,20 +2836,71 @@
       }
     },
     "snarkjs": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/snarkjs/-/snarkjs-0.5.0.tgz",
-      "integrity": "sha512-KWz8mZ2Y+6wvn6GGkQo6/ZlKwETdAGohd40Lzpwp5TUZCn6N6O4Az1SuX1rw/qREGL6Im+ycb19suCFE8/xaKA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/snarkjs/-/snarkjs-0.7.0.tgz",
+      "integrity": "sha512-Vu5W+0Va6X1xvlCllpZ2r3/S7MafnL6IrAv09lk/F+VNDHuHEHx3xopR9Kr70p2KpbBBJ/HB9VCDZWism8WGlA==",
       "requires": {
         "@iden3/binfileutils": "0.0.11",
         "bfj": "^7.0.2",
         "blake2b-wasm": "^2.4.0",
-        "circom_runtime": "0.1.21",
+        "circom_runtime": "0.1.22",
         "ejs": "^3.1.6",
         "fastfile": "0.0.20",
-        "ffjavascript": "0.2.56",
+        "ffjavascript": "0.2.59",
         "js-sha3": "^0.8.0",
         "logplease": "^1.2.15",
-        "r1csfile": "0.0.41"
+        "r1csfile": "0.0.45"
+      },
+      "dependencies": {
+        "ffjavascript": {
+          "version": "0.2.59",
+          "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.59.tgz",
+          "integrity": "sha512-QssOEUv+wilz9Sg7Zaj6KWAm7QceOAEsFuEBTltUsDo1cjn11rA/LGYvzFBPbzNfxRlZxwgJ7uxpCQcdDlrNfw==",
+          "requires": {
+            "wasmbuilder": "0.0.16",
+            "wasmcurves": "0.2.1",
+            "web-worker": "^1.2.0"
+          }
+        },
+        "r1csfile": {
+          "version": "0.0.45",
+          "resolved": "https://registry.npmjs.org/r1csfile/-/r1csfile-0.0.45.tgz",
+          "integrity": "sha512-YKIp4D441aZ6OoI9y+bfAyb2j4Cl+OFq/iiX6pPWDrL4ZO968h0dq0w07i65edvrTt7/G43mTnl0qEuLXyp/Yw==",
+          "requires": {
+            "@iden3/bigarray": "0.0.2",
+            "@iden3/binfileutils": "0.0.11",
+            "fastfile": "0.0.20",
+            "ffjavascript": "0.2.57"
+          },
+          "dependencies": {
+            "ffjavascript": {
+              "version": "0.2.57",
+              "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.57.tgz",
+              "integrity": "sha512-V+vxZ/zPNcthrWmqfe/1YGgqdkTamJeXiED0tsk7B84g40DKlrTdx47IqZuiygqAVG6zMw4qYuvXftIJWsmfKQ==",
+              "requires": {
+                "wasmbuilder": "0.0.16",
+                "wasmcurves": "0.2.0",
+                "web-worker": "^1.2.0"
+              }
+            },
+            "wasmcurves": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.2.0.tgz",
+              "integrity": "sha512-3e2rbxdujOwaod657gxgmdhZNn+i1qKdHO3Y/bK+8E7bV8ttV/fu5FO4/WLBACF375cK0QDLOP+65Na63qYuWA==",
+              "requires": {
+                "wasmbuilder": "0.0.16"
+              }
+            }
+          }
+        },
+        "wasmcurves": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/wasmcurves/-/wasmcurves-0.2.1.tgz",
+          "integrity": "sha512-9ciO7bUE5bgpbOcdK7IO3enrSVIKHwrQmPibok4GLJWaCA7Wyqc9PRYnu5HbiFv9NDFNqVKPtU5R6Is5KujBLg==",
+          "requires": {
+            "wasmbuilder": "0.0.16"
+          }
+        }
       }
     },
     "string-width": {
@@ -2888,15 +3002,14 @@
       }
     },
     "util": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
       "requires": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
         "is-generator-function": "^1.0.7",
         "is-typed-array": "^1.1.3",
-        "safe-buffer": "^5.1.2",
         "which-typed-array": "^1.1.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -24,17 +24,16 @@
   "homepage": "https://github.com/iden3/circom_tester#readme",
   "dependencies": {
     "chai": "^4.3.6",
-    "child_process": "^1.0.2",
-    "ffjavascript": "^0.2.56",
+    "ffjavascript": "^0.2.60",
     "fnv-plus": "^1.3.1",
-    "r1csfile": "^0.0.41",
+    "r1csfile": "^0.0.47",
     "tmp-promise": "^3.0.3",
-    "util": "^0.12.4",
-    "snarkjs": "0.5.0"
+    "util": "^0.12.5",
+    "snarkjs": "^0.7.0"
   },
   "devDependencies": {
-    "@types/chai": "^4.3.1",
-    "@types/mocha": "^9.1.1",
-    "mocha": "^10.0.0"
+    "@types/chai": "^4.3.6",
+    "@types/mocha": "^10.0.1",
+    "mocha": "^10.1.0"
   }
 }

--- a/test/Multiplier2.circom
+++ b/test/Multiplier2.circom
@@ -8,4 +8,3 @@ template Multiplier2() {
 }
 
 component main = Multiplier2();
- 

--- a/test/multiplier2.js
+++ b/test/multiplier2.js
@@ -16,38 +16,40 @@ describe("Simple test", function () {
     it("Checking the compilation of a simple circuit generating wasm", async function () {
 
         const circuit = await wasm_tester(
-	    path.join(__dirname, "Multiplier2.circom")
-	);
+            path.join(__dirname, "Multiplier2.circom")
+        );
         const w = await circuit.calculateWitness({a: 2, b: 4});
         await circuit.checkConstraints(w);
     });
-    
+
     it("Checking the compilation of a simple circuit generating wasm in a given folder", async function () {
         const circuit = await wasm_tester(
-	    path.join(__dirname, "Multiplier2.circom"),
-	    { output : path.join(__dirname),
-	    }
-	);
+            path.join(__dirname, "Multiplier2.circom"),
+            {
+                output: path.join(__dirname),
+            }
+        );
         const w = await circuit.calculateWitness({a: 2, b: 4});
         await circuit.checkConstraints(w);
     });
-    
+
     it("Checking the compilation of a simple circuit generating wasm in a given folder without recompiling", async function () {
         const circuit = await wasm_tester(
-	    path.join(__dirname, "Multiplier2.circom"),
-	    { output : path.join(__dirname),
-	      recompile : false,
-	    }
-	);
+            path.join(__dirname, "Multiplier2.circom"),
+            {
+                output: path.join(__dirname),
+                recompile: false,
+            }
+        );
         const w = await circuit.calculateWitness({a: 6, b: 3});
         await circuit.checkConstraints(w);
-	
+
     });
 
     it("Checking the compilation of a simple circuit generating C", async function () {
         const circuit = await c_tester(
-	    path.join(__dirname, "Multiplier2.circom")
-	);
+            path.join(__dirname, "Multiplier2.circom")
+        );
         try {
             const w = await circuit.calculateWitness({a: 2, b: 4});
             await circuit.checkConstraints(w);
@@ -65,10 +67,11 @@ describe("Simple test", function () {
 
     it("Checking the compilation of a simple circuit generating C in a given folder", async function () {
         const circuit = await c_tester(
-	    path.join(__dirname, "Multiplier2.circom"),
-	    { output : path.join(__dirname),
-	    }
-	);
+            path.join(__dirname, "Multiplier2.circom"),
+            {
+                output: path.join(__dirname),
+            }
+        );
         try {
             const w = await circuit.calculateWitness({a: 2, b: 4});
             await circuit.checkConstraints(w);
@@ -83,11 +86,12 @@ describe("Simple test", function () {
 
     it("Checking the compilation of a simple circuit generating C in a given folder without recompiling", async function () {
         const circuit = await c_tester(
-	    path.join(__dirname, "Multiplier2.circom"),
-	    { output : path.join(__dirname),
-	      recompile : false,
-	    }
-	);
+            path.join(__dirname, "Multiplier2.circom"),
+            {
+                output: path.join(__dirname),
+                recompile: false,
+            }
+        );
         try {
             const w = await circuit.calculateWitness({a: 6, b: 3});
             await circuit.checkConstraints(w);

--- a/wasm/tester.js
+++ b/wasm/tester.js
@@ -81,6 +81,7 @@ async function compile(fileName, options) {
     if (options.O === 0) flags += "--O0 ";
     if (options.O === 1) flags += "--O1 ";
     if (options.verbose) flags += "--verbose ";
+    if (options.inspect) flags += "--inspect ";
 
     try {
         let b = await exec("circom " + flags + fileName);

--- a/wasm/tester.js
+++ b/wasm/tester.js
@@ -63,7 +63,7 @@ async function  wasm_tester(circomInput, _options) {
 }
 
 async function compile (fileName, options) {
-    var flags = "--wasm ";
+    let flags = "--wasm ";
     if (options.include) {
         if (Array.isArray(options.include)) {
             for (let i=0; i<options.include.length;i++) {
@@ -83,10 +83,13 @@ async function compile (fileName, options) {
     if (options.verbose) flags += "--verbose ";
 
     try {
-	b = await exec("circom " + flags + fileName);
+	let b = await exec("circom " + flags + fileName);
 	if (options.verbose) {
             console.log(b.stdout);
 	}
+        if (b.stderr) {
+            console.error(b.stderr);
+        }
     } catch (e) {
 	assert(false,
 	       "circom compiler error \n" + e);

--- a/wasm/tester.js
+++ b/wasm/tester.js
@@ -236,6 +236,6 @@ function check_versions ( v1, v2 ) {
 async function compiler_above_version(v) {
     let output = (await exec('circom --version')).stdout;
     let compiler_version = version_to_list(output.slice(output.search(/\d/),-1));
-    vlist = version_to_list(v);
+    let vlist = version_to_list(v);
     return check_versions ( compiler_version, vlist );
 }

--- a/wasm/tester.js
+++ b/wasm/tester.js
@@ -2,11 +2,11 @@ const chai = require("chai");
 const assert = chai.assert;
 
 const fs = require("fs");
-var tmp = require("tmp-promise");
+const tmp = require("tmp-promise");
 const path = require("path");
 
 const util = require("util");
-const { F1Field } = require("ffjavascript");
+const {F1Field} = require("ffjavascript");
 const exec = util.promisify(require("child_process").exec);
 
 const readR1cs = require("r1csfile").readR1cs;
@@ -14,9 +14,9 @@ const ZqField = require("ffjavascript").ZqField;
 
 module.exports = wasm_tester;
 
-async function  wasm_tester(circomInput, _options) {
+async function wasm_tester(circomInput, _options) {
 
-    assert(await compiler_above_version("2.0.0"),"Wrong compiler version. Must be at least 2.0.0");
+    assert(await compiler_above_version("2.0.0"), "Wrong compiler version. Must be at least 2.0.0");
 
     const baseName = path.basename(circomInput, ".circom");
     const options = Object.assign({}, _options);
@@ -26,51 +26,51 @@ async function  wasm_tester(circomInput, _options) {
     options.sym = true;
     options.json = options.json || false; // costraints in json format
     options.r1cs = true;
-    options.compile = (typeof options.recompile  === 'undefined')? true : options.recompile; // by default compile
+    options.compile = (typeof options.recompile === 'undefined') ? true : options.recompile; // by default compile
 
-    if (typeof options.output  === 'undefined') {
-	tmp.setGracefulCleanup();
-        const dir = await tmp.dir({prefix: "circom_", unsafeCleanup: true });
-	//console.log(dir.path);
-	options.output = dir.path;
+    if (typeof options.output === 'undefined') {
+        tmp.setGracefulCleanup();
+        const dir = await tmp.dir({prefix: "circom_", unsafeCleanup: true});
+        //console.log(dir.path);
+        options.output = dir.path;
     } else {
-	try {
+        try {
             await fs.promises.access(options.output);
-	} catch (err) {
-	    assert(options.compile,"Cannot set recompile to false if the output path does not exist");
-	    await fs.promises.mkdir(options.output, { recursive: true });
-	}
+        } catch (err) {
+            assert(options.compile, "Cannot set recompile to false if the output path does not exist");
+            await fs.promises.mkdir(options.output, {recursive: true});
+        }
     }
     if (options.compile) {
-	await compile(circomInput, options);
+        await compile(circomInput, options);
     } else {
-	const jsPath = path.join(options.output, baseName+"_js");
-	try {
-	    await fs.promises.access(jsPath);
-	} catch (err) {
-	    assert(false,"Cannot set recompile to false if the "+jsPath+" folder does not exist");
-	}
+        const jsPath = path.join(options.output, baseName + "_js");
+        try {
+            await fs.promises.access(jsPath);
+        } catch (err) {
+            assert(false, "Cannot set recompile to false if the " + jsPath + " folder does not exist");
+        }
     }
 
     const utils = require("./utils");
     const WitnessCalculator = require("./witness_calculator");
 
-    const wasm = await fs.promises.readFile(path.join(options.output, baseName+"_js/"+ baseName + ".wasm"));
+    const wasm = await fs.promises.readFile(path.join(options.output, baseName + "_js/" + baseName + ".wasm"));
 
     const wc = await WitnessCalculator(wasm);
 
     return new WasmTester(options.output, baseName, wc);
 }
 
-async function compile (fileName, options) {
+async function compile(fileName, options) {
     let flags = "--wasm ";
     if (options.include) {
         if (Array.isArray(options.include)) {
-            for (let i=0; i<options.include.length;i++) {
-                flags += "-l "+options.include[i] + " ";
+            for (let i = 0; i < options.include.length; i++) {
+                flags += "-l " + options.include[i] + " ";
             }
         } else {
-            flags += "-l "+options.include + " ";
+            flags += "-l " + options.include + " ";
         }
     }
     if (options.sym) flags += "--sym ";
@@ -84,22 +84,22 @@ async function compile (fileName, options) {
 
     try {
         let b = await exec("circom " + flags + fileName);
-	if (options.verbose) {
+        if (options.verbose) {
             console.log(b.stdout);
-	}
+        }
         if (b.stderr) {
             console.error(b.stderr);
         }
     } catch (e) {
-	      assert(false,
-	             "circom compiler error \n" + e);
+        assert(false,
+            "circom compiler error \n" + e);
     }
 }
 
 class WasmTester {
 
     constructor(dir, baseName, witnessCalculator) {
-        this.dir=dir;
+        this.dir = dir;
         this.baseName = baseName;
         this.witnessCalculator = witnessCalculator;
     }
@@ -120,9 +120,9 @@ class WasmTester {
             "utf8"
         );
         const lines = symsStr.split("\n");
-        for (let i=0; i<lines.length; i++) {
+        for (let i = 0; i < lines.length; i++) {
             const arr = lines[i].split(",");
-            if (arr.length!=4) continue;
+            if (arr.length != 4) continue;
             this.symbols[arr[3]] = {
                 labelIdx: Number(arr[0]),
                 varIdx: Number(arr[1]),
@@ -134,7 +134,7 @@ class WasmTester {
     async loadConstraints() {
         const self = this;
         if (this.constraints) return;
-        const r1cs = await readR1cs(path.join(this.dir, this.baseName + ".r1cs"),{
+        const r1cs = await readR1cs(path.join(this.dir, this.baseName + ".r1cs"), {
             loadConstraints: true,
             loadMap: false,
             getFieldFromPrime: (p, singlethread) => new F1Field(p)
@@ -153,16 +153,16 @@ class WasmTester {
         function checkObject(prefix, eOut) {
 
             if (Array.isArray(eOut)) {
-                for (let i=0; i<eOut.length; i++) {
-                    checkObject(prefix + "["+i+"]", eOut[i]);
+                for (let i = 0; i < eOut.length; i++) {
+                    checkObject(prefix + "[" + i + "]", eOut[i]);
                 }
-            } else if ((typeof eOut == "object")&&(eOut.constructor.name == "Object")) {
+            } else if ((typeof eOut == "object") && (eOut.constructor.name == "Object")) {
                 for (let k in eOut) {
-                    checkObject(prefix + "."+k, eOut[k]);
+                    checkObject(prefix + "." + k, eOut[k]);
                 }
             } else {
                 if (typeof self.symbols[prefix] == "undefined") {
-                    assert(false, "Output variable not defined: "+ prefix);
+                    assert(false, "Output variable not defined: " + prefix);
                 }
                 const ba = actualOut[self.symbols[prefix].varIdx].toString();
                 const be = eOut.toString();
@@ -190,7 +190,7 @@ class WasmTester {
     async checkConstraints(witness) {
         const self = this;
         if (!self.constraints) await self.loadConstraints();
-        for (let i=0; i<self.constraints.length; i++) {
+        for (let i = 0; i < self.constraints.length; i++) {
             checkConstraint(self.constraints[i]);
         }
 
@@ -200,7 +200,7 @@ class WasmTester {
             const a = evalLC(constraint[0]);
             const b = evalLC(constraint[1]);
             const c = evalLC(constraint[2]);
-            assert (F.isZero(F.sub(F.mul(a,b), c)), "Constraint doesn't match");
+            assert(F.isZero(F.sub(F.mul(a, b), c)), "Constraint doesn't match");
         }
 
         function evalLC(lc) {
@@ -209,7 +209,7 @@ class WasmTester {
             for (let w in lc) {
                 v = F.add(
                     v,
-                    F.mul( lc[w], F.e(witness[w]) )
+                    F.mul(lc[w], F.e(witness[w]))
                 );
             }
             return v;
@@ -218,24 +218,24 @@ class WasmTester {
 
 }
 
-function version_to_list ( v ) {
-    return v.split(".").map(function(x) {
-	return parseInt(x, 10);
+function version_to_list(v) {
+    return v.split(".").map(function (x) {
+        return parseInt(x, 10);
     });
 }
 
-function check_versions ( v1, v2 ) {
+function check_versions(v1, v2) {
     //check if v1 is newer than or equal to v2
     for (let i = 0; i < v2.length; i++) {
-	if (v1[i] > v2[i]) return true;
-	if (v1[i] < v2[i]) return false;
+        if (v1[i] > v2[i]) return true;
+        if (v1[i] < v2[i]) return false;
     }
     return true;
 }
 
 async function compiler_above_version(v) {
     let output = (await exec('circom --version')).stdout;
-    let compiler_version = version_to_list(output.slice(output.search(/\d/),-1));
+    let compiler_version = version_to_list(output.slice(output.search(/\d/), -1));
     let vlist = version_to_list(v);
-    return check_versions ( compiler_version, vlist );
+    return check_versions(compiler_version, vlist);
 }

--- a/wasm/utils.js
+++ b/wasm/utils.js
@@ -6,19 +6,19 @@ module.exports.fromArray32 = fromArray32;
 module.exports.flatArray = flatArray;
 module.exports.normalize = normalize;
 
-function toArray32(rem,size) {
+function toArray32(rem, size) {
     const res = []; //new Uint32Array(size); //has no unshift
     const radix = BigInt(0x100000000);
     while (rem) {
-        res.unshift( Number(rem % radix));
+        res.unshift(Number(rem % radix));
         rem = rem / radix;
     }
     if (size) {
-	var i = size - res.length;
-	while (i>0) {
-	    res.unshift(0);
-	    i--;
-	}
+        var i = size - res.length;
+        while (i > 0) {
+            res.unshift(0);
+            i--;
+        }
     }
     return res;
 }
@@ -26,8 +26,8 @@ function toArray32(rem,size) {
 function fromArray32(arr) { //returns a BigInt
     var res = BigInt(0);
     const radix = BigInt(0x100000000);
-    for (let i = 0; i<arr.length; i++) {
-        res = res*radix + BigInt(arr[i]);
+    for (let i = 0; i < arr.length; i++) {
+        res = res * radix + BigInt(arr[i]);
     }
     return res;
 }
@@ -39,7 +39,7 @@ function flatArray(a) {
 
     function fillArray(res, a) {
         if (Array.isArray(a)) {
-            for (let i=0; i<a.length; i++) {
+            for (let i = 0; i < a.length; i++) {
                 fillArray(res, a[i]);
             }
         } else {

--- a/wasm/witness_calculator.js
+++ b/wasm/witness_calculator.js
@@ -6,11 +6,11 @@ module.exports = async function builder(code, options) {
 
     let wasmModule;
     try {
-	wasmModule = await WebAssembly.compile(code);
-    }  catch (err) {
-	console.log(err);
-	console.log("\nTry to run circom --c in order to generate c++ code instead\n");
-	throw new Error(err);
+        wasmModule = await WebAssembly.compile(code);
+    } catch (err) {
+        console.log(err);
+        console.log("\nTry to run circom --c in order to generate c++ code instead\n");
+        throw new Error(err);
     }
 
     let wc;
@@ -20,46 +20,46 @@ module.exports = async function builder(code, options) {
 
     const instance = await WebAssembly.instantiate(wasmModule, {
         runtime: {
-            exceptionHandler : function(code) {
-		let err;
-                if (code == 1) {
+            exceptionHandler: function (code) {
+                let err;
+                if (code === 1) {
                     err = "Signal not found.\n";
-                } else if (code == 2) {
+                } else if (code === 2) {
                     err = "Too many signals set.\n";
-                } else if (code == 3) {
+                } else if (code === 3) {
                     err = "Signal already set.\n";
-		} else if (code == 4) {
+                } else if (code === 4) {
                     err = "Assert Failed.\n";
-		} else if (code == 5) {
+                } else if (code === 5) {
                     err = "Not enough memory.\n";
-		} else if (code == 6) {
+                } else if (code === 6) {
                     err = "Input signal array access exceeds the size.\n";
-		} else {
-		    err = "Unknown error.\n";
+                } else {
+                    err = "Unknown error.\n";
                 }
                 throw new Error(err + errStr);
             },
-	    printErrorMessage : function() {
-		errStr += getMessage() + "\n";
+            printErrorMessage: function () {
+                errStr += getMessage() + "\n";
                 // console.error(getMessage());
-	    },
-	    writeBufferMessage : function() {
-			const msg = getMessage();
-			// Any calls to `log()` will always end with a `\n`, so that's when we print and reset
-			if (msg === "\n") {
-				console.log(msgStr);
-				msgStr = "";
-			} else {
-				// If we've buffered other content, put a space in between the items
-				if (msgStr !== "") {
-					msgStr += " "
-				}
-				// Then append the message to the message we are creating
-				msgStr += msg;
-			}
-	    },
-	    showSharedRWMemory : function() {
-		printSharedRWMemory ();
+            },
+            writeBufferMessage: function () {
+                const msg = getMessage();
+                // Any calls to `log()` will always end with a `\n`, so that's when we print and reset
+                if (msg === "\n") {
+                    console.log(msgStr);
+                    msgStr = "";
+                } else {
+                    // If we've buffered other content, put a space in between the items
+                    if (msgStr !== "") {
+                        msgStr += " "
+                    }
+                    // Then append the message to the message we are creating
+                    msgStr += msg;
+                }
+            },
+            showSharedRWMemory: function () {
+                printSharedRWMemory();
             }
 
         }
@@ -81,29 +81,29 @@ module.exports = async function builder(code, options) {
     return wc;
 
     function getMessage() {
-        var message = "";
-	var c = instance.exports.getMessageChar();
-        while ( c != 0 ) {
-	    message += String.fromCharCode(c);
-	    c = instance.exports.getMessageChar();
-	}
+        let message = "";
+        let c = instance.exports.getMessageChar();
+        while (c != 0) {
+            message += String.fromCharCode(c);
+            c = instance.exports.getMessageChar();
+        }
         return message;
     }
 
-    function printSharedRWMemory () {
-	const shared_rw_memory_size = instance.exports.getFieldNumLen32();
-	const arr = new Uint32Array(shared_rw_memory_size);
-	for (let j=0; j<shared_rw_memory_size; j++) {
-	    arr[shared_rw_memory_size-1-j] = instance.exports.readSharedRWMemory(j);
-	}
+    function printSharedRWMemory() {
+        const shared_rw_memory_size = instance.exports.getFieldNumLen32();
+        const arr = new Uint32Array(shared_rw_memory_size);
+        for (let j = 0; j < shared_rw_memory_size; j++) {
+            arr[shared_rw_memory_size - 1 - j] = instance.exports.readSharedRWMemory(j);
+        }
 
-	// If we've buffered other content, put a space in between the items
-	if (msgStr !== "") {
-		msgStr += " "
-	}
-	// Then append the value to the message we are creating
-	msgStr += (utils.fromArray32(arr).toString());
-	}
+        // If we've buffered other content, put a space in between the items
+        if (msgStr !== "") {
+            msgStr += " "
+        }
+        // Then append the value to the message we are creating
+        msgStr += (utils.fromArray32(arr).toString());
+    }
 
 };
 
@@ -111,13 +111,13 @@ class WitnessCalculator {
     constructor(instance, sanityCheck) {
         this.instance = instance;
 
-	this.version = this.instance.exports.getVersion();
+        this.version = this.instance.exports.getVersion();
         this.n32 = this.instance.exports.getFieldNumLen32();
 
         this.instance.exports.getRawPrime();
         const arr = new Uint32Array(this.n32);
-        for (let i=0; i<this.n32; i++) {
-            arr[this.n32-1-i] = this.instance.exports.readSharedRWMemory(i);
+        for (let i = 0; i < this.n32; i++) {
+            arr[this.n32 - 1 - i] = this.instance.exports.readSharedRWMemory(i);
         }
         this.prime = utils.fromArray32(arr);
 
@@ -127,47 +127,47 @@ class WitnessCalculator {
     }
 
     circom_version() {
-	return this.instance.exports.getVersion();
+        return this.instance.exports.getVersion();
     }
 
     async _doCalculateWitness(input, sanityCheck) {
-	//input is assumed to be a map from signals to arrays of bigints
+        //input is assumed to be a map from signals to arrays of bigints
         this.instance.exports.init((this.sanityCheck || sanityCheck) ? 1 : 0);
         const keys = Object.keys(input);
-	var input_counter = 0;
-        keys.forEach( (k) => {
+        let input_counter = 0;
+        keys.forEach((k) => {
             const h = utils.fnvHash(k);
-            const hMSB = parseInt(h.slice(0,8), 16);
-            const hLSB = parseInt(h.slice(8,16), 16);
+            const hMSB = parseInt(h.slice(0, 8), 16);
+            const hLSB = parseInt(h.slice(8, 16), 16);
             const fArr = utils.flatArray(input[k]);
-	    let signalSize = this.instance.exports.getInputSignalSize(hMSB, hLSB);
-	    if (signalSize < 0){
-		throw new Error(`Signal ${k} not found\n`);
-	    }
-	    if (fArr.length < signalSize) {
-		throw new Error(`Not enough values for input signal ${k}\n`);
-	    }
-	    if (fArr.length > signalSize) {
-		throw new Error(`Too many values for input signal ${k}\n`);
-	    }
-            for (let i=0; i<fArr.length; i++) {
-		const arrFr = utils.toArray32(utils.normalize(fArr[i],this.prime),this.n32)
-		for (let j=0; j<this.n32; j++) {
-		    this.instance.exports.writeSharedRWMemory(j,arrFr[this.n32-1-j]);
-		}
-		try {
-                    this.instance.exports.setInputSignal(hMSB, hLSB,i);
-		    input_counter++;
-		} catch (err) {
-		    // console.log(`After adding signal ${i} of ${k}`)
+            let signalSize = this.instance.exports.getInputSignalSize(hMSB, hLSB);
+            if (signalSize < 0) {
+                throw new Error(`Signal ${k} not found\n`);
+            }
+            if (fArr.length < signalSize) {
+                throw new Error(`Not enough values for input signal ${k}\n`);
+            }
+            if (fArr.length > signalSize) {
+                throw new Error(`Too many values for input signal ${k}\n`);
+            }
+            for (let i = 0; i < fArr.length; i++) {
+                const arrFr = utils.toArray32(utils.normalize(fArr[i], this.prime), this.n32)
+                for (let j = 0; j < this.n32; j++) {
+                    this.instance.exports.writeSharedRWMemory(j, arrFr[this.n32 - 1 - j]);
+                }
+                try {
+                    this.instance.exports.setInputSignal(hMSB, hLSB, i);
+                    input_counter++;
+                } catch (err) {
+                    // console.log(`After adding signal ${i} of ${k}`)
                     throw new Error(err);
-		}
+                }
             }
 
         });
-	if (input_counter < this.instance.exports.getInputSize()) {
-	    throw new Error(`Not all inputs have been set. Only ${input_counter} out of ${this.instance.exports.getInputSize()}`);
-	}
+        if (input_counter < this.instance.exports.getInputSize()) {
+            throw new Error(`Not all inputs have been set. Only ${input_counter} out of ${this.instance.exports.getInputSize()}`);
+        }
     }
 
     async calculateWitness(input, sanityCheck) {
@@ -176,11 +176,11 @@ class WitnessCalculator {
 
         await this._doCalculateWitness(input, sanityCheck);
 
-        for (let i=0; i<this.witnessSize; i++) {
+        for (let i = 0; i < this.witnessSize; i++) {
             this.instance.exports.getWitness(i);
-	    const arr = new Uint32Array(this.n32);
-            for (let j=0; j<this.n32; j++) {
-            arr[this.n32-1-j] = this.instance.exports.readSharedRWMemory(j);
+            const arr = new Uint32Array(this.n32);
+            for (let j = 0; j < this.n32; j++) {
+                arr[this.n32 - 1 - j] = this.instance.exports.readSharedRWMemory(j);
             }
             w.push(utils.fromArray32(arr));
         }
@@ -191,86 +191,86 @@ class WitnessCalculator {
 
     async calculateBinWitness(input, sanityCheck) {
 
-        const buff32 = new Uint32Array(this.witnessSize*this.n32);
-	const buff = new  Uint8Array( buff32.buffer);
+        const buff32 = new Uint32Array(this.witnessSize * this.n32);
+        const buff = new Uint8Array(buff32.buffer);
         await this._doCalculateWitness(input, sanityCheck);
 
-        for (let i=0; i<this.witnessSize; i++) {
+        for (let i = 0; i < this.witnessSize; i++) {
             this.instance.exports.getWitness(i);
-	    const pos = i*this.n32;
-            for (let j=0; j<this.n32; j++) {
-		buff32[pos+j] = this.instance.exports.readSharedRWMemory(j);
+            const pos = i * this.n32;
+            for (let j = 0; j < this.n32; j++) {
+                buff32[pos + j] = this.instance.exports.readSharedRWMemory(j);
             }
         }
 
-	return buff;
+        return buff;
     }
 
 
     async calculateWTNSBin(input, sanityCheck) {
 
-        const buff32 = new Uint32Array(this.witnessSize*this.n32+this.n32+11);
-	const buff = new  Uint8Array( buff32.buffer);
+        const buff32 = new Uint32Array(this.witnessSize * this.n32 + this.n32 + 11);
+        const buff = new Uint8Array(buff32.buffer);
         await this._doCalculateWitness(input, sanityCheck);
 
-	//"wtns"
-	buff[0] = "w".charCodeAt(0)
-	buff[1] = "t".charCodeAt(0)
-	buff[2] = "n".charCodeAt(0)
-	buff[3] = "s".charCodeAt(0)
+        //"wtns"
+        buff[0] = "w".charCodeAt(0)
+        buff[1] = "t".charCodeAt(0)
+        buff[2] = "n".charCodeAt(0)
+        buff[3] = "s".charCodeAt(0)
 
-	//version 2
-	buff32[1] = 2;
+        //version 2
+        buff32[1] = 2;
 
-	//number of sections: 2
-	buff32[2] = 2;
+        //number of sections: 2
+        buff32[2] = 2;
 
-	//id section 1
-	buff32[3] = 1;
+        //id section 1
+        buff32[3] = 1;
 
-	const n8 = this.n32*4;
-	//id section 1 length in 64bytes
-	const idSection1length = 8 + n8;
-	const idSection1lengthHex = idSection1length.toString(16);
-        buff32[4] = parseInt(idSection1lengthHex.slice(0,8), 16);
-        buff32[5] = parseInt(idSection1lengthHex.slice(8,16), 16);
+        const n8 = this.n32 * 4;
+        //id section 1 length in 64bytes
+        const idSection1length = 8 + n8;
+        const idSection1lengthHex = idSection1length.toString(16);
+        buff32[4] = parseInt(idSection1lengthHex.slice(0, 8), 16);
+        buff32[5] = parseInt(idSection1lengthHex.slice(8, 16), 16);
 
-	//this.n32
-	buff32[6] = n8;
+        //this.n32
+        buff32[6] = n8;
 
-	//prime number
-	this.instance.exports.getRawPrime();
+        //prime number
+        this.instance.exports.getRawPrime();
 
-	var pos = 7;
-        for (let j=0; j<this.n32; j++) {
-	    buff32[pos+j] = this.instance.exports.readSharedRWMemory(j);
+        let pos = 7;
+        for (let j = 0; j < this.n32; j++) {
+            buff32[pos + j] = this.instance.exports.readSharedRWMemory(j);
         }
-	pos += this.n32;
+        pos += this.n32;
 
-	// witness size
-	buff32[pos] = this.witnessSize;
-	pos++;
+        // witness size
+        buff32[pos] = this.witnessSize;
+        pos++;
 
-	//id section 2
-	buff32[pos] = 2;
-	pos++;
+        //id section 2
+        buff32[pos] = 2;
+        pos++;
 
-	// section 2 length
-	const idSection2length = n8*this.witnessSize;
-	const idSection2lengthHex = idSection2length.toString(16);
-        buff32[pos] = parseInt(idSection2lengthHex.slice(0,8), 16);
-        buff32[pos+1] = parseInt(idSection2lengthHex.slice(8,16), 16);
+        // section 2 length
+        const idSection2length = n8 * this.witnessSize;
+        const idSection2lengthHex = idSection2length.toString(16);
+        buff32[pos] = parseInt(idSection2lengthHex.slice(0, 8), 16);
+        buff32[pos + 1] = parseInt(idSection2lengthHex.slice(8, 16), 16);
 
-	pos += 2;
-        for (let i=0; i<this.witnessSize; i++) {
+        pos += 2;
+        for (let i = 0; i < this.witnessSize; i++) {
             this.instance.exports.getWitness(i);
-            for (let j=0; j<this.n32; j++) {
-		buff32[pos+j] = this.instance.exports.readSharedRWMemory(j);
+            for (let j = 0; j < this.n32; j++) {
+                buff32[pos + j] = this.instance.exports.readSharedRWMemory(j);
             }
-	    pos += this.n32;
+            pos += this.n32;
         }
 
-	return buff;
+        return buff;
     }
 
 }


### PR DESCRIPTION
* Fixes a problem that when make prints warning to stderr circom_tester would fail in assert. I changed behavior to printing stderr from make instead of failing.
* Added support of inspect flag for circuit compilation.
* Fixed code formatting.
* Fixed var instantiation (use `let` and `const` instead of `var`)
* Updated dependencies, as there were vulnerable ones. Fixes #16 